### PR TITLE
ベンチマーク結果を Mackerel のサービスメトリックとして投稿できるようにする

### DIFF
--- a/benchmarker/.env.sample
+++ b/benchmarker/.env.sample
@@ -1,0 +1,7 @@
+# Mackerel のサービスメトリックになるのでチーム名は [a-zA-Z0-9_-]+ で指定してください
+TEAMNAME=
+# アプリケーションインスタンスの Private IP を指定してください
+APP_IP=
+MACKEREL_APIKEY=
+MACKEREL_SERVICE=
+MACKEREL_SERVICE_METRIC_PREFIX=

--- a/benchmarker/.gitignore
+++ b/benchmarker/.gitignore
@@ -1,2 +1,3 @@
 *.test
 bin/
+.env

--- a/benchmarker/benchmarker.sh
+++ b/benchmarker/benchmarker.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# ./benchmark.sh [option]
+# Options:
+#   --workload	N	run benchmark with N workloads (default: 3)
+
+DIR=$(dirname $0)
+
+# load env
+# https://songmu.jp/riji/entry/2019-06-14-bash-dotenv.html
+set -o allexport
+source $DIR/.env
+set +o allexport
+
+if [ -z $TEAMNAME ]; then
+    echo 'You need to specify team name'
+    exit 1
+fi
+
+$DIR/bin/benchmarker -u $DIR/userdata -t http://$APP_IP/ "$@" | tee | /opt/mackerel-agent/plugins/bin/mackerel-plugin-json -stdin -prefix $MACKEREL_SERVICE_METRIC_PREFIX -include score | sed "s/score/score-$TEAMNAME/" | mkr throw -s $MACKEREL_SERVICE

--- a/benchmarker/benchmarker.sh
+++ b/benchmarker/benchmarker.sh
@@ -16,4 +16,4 @@ if [ -z $TEAMNAME ]; then
     exit 1
 fi
 
-$DIR/bin/benchmarker -u $DIR/userdata -t http://$APP_IP/ "$@" | tee | /opt/mackerel-agent/plugins/bin/mackerel-plugin-json -stdin -prefix $MACKEREL_SERVICE_METRIC_PREFIX -include score | sed "s/score/score-$TEAMNAME/" | mkr throw -s $MACKEREL_SERVICE
+$DIR/bin/benchmarker -u $DIR/userdata -t http://$APP_IP/ "$@" | tee /dev/stderr | /opt/mackerel-agent/plugins/bin/mackerel-plugin-json -stdin -prefix $MACKEREL_SERVICE_METRIC_PREFIX -include score | sed "s/score/score-$TEAMNAME/" | mkr throw -s $MACKEREL_SERVICE

--- a/benchmarker/benchmarker.sh
+++ b/benchmarker/benchmarker.sh
@@ -16,4 +16,4 @@ if [ -z $TEAMNAME ]; then
     exit 1
 fi
 
-$DIR/bin/benchmarker -u $DIR/userdata -t http://$APP_IP/ "$@" | tee /dev/stderr | /opt/mackerel-agent/plugins/bin/mackerel-plugin-json -stdin -prefix $MACKEREL_SERVICE_METRIC_PREFIX -include score | sed "s/score/score-$TEAMNAME/" | mkr throw -s $MACKEREL_SERVICE
+$DIR/bin/benchmarker -u $DIR/userdata -t http://$APP_IP/ "$@" | tee /dev/stderr | jq {score} | /opt/mackerel-agent/plugins/bin/mackerel-plugin-json -stdin -prefix $MACKEREL_SERVICE_METRIC_PREFIX -include score | sed "s/score/score-$TEAMNAME/" | mkr throw -s $MACKEREL_SERVICE


### PR DESCRIPTION
お馴染み https://github.com/astj/ISHOCON2/pull/1

- ベンチマーカーが吐いた生の json を食わすと mackerel-plugin-json が panic するので jq で必要なフィールドだけ残してる
  - AMI 焼くときは mkr の他に jq も入れてね
- なんか今までのやつの tee ちゃんと動いてなかった気がする